### PR TITLE
Remove GPT Engineer script

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,6 @@
 
   <body>
     <div id="root"></div>
-    <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
-    <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- delete gptengineer script from `index.html`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b78a31c50832ba84d0222c0f5f963

## Resumo por Sourcery

Tarefas:
- Remover a tag de script do GPT Engineer e seu comentário do index.html

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Remove GPT Engineer script tag and its comment from index.html

</details>