### PR TITLE
Replace anchor with Link in NotFound

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -16,9 +16,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- use `<Link>` from react-router-dom in the NotFound page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b79adf5bc832ba83120beac7bc4e1

## Resumo por Sourcery

Melhorias:
- Substituir a tag `<a>` por `<Link>` em NotFound para habilitar o roteamento do lado do cliente

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace <a> tag with <Link> in NotFound to enable client-side routing

</details>