### PR TITLE
Add deployment instructions for subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,18 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Deploying under `/prefeituras` on www.iaprojetos.com.br
+
+When hosting the app at `https://www.iaprojetos.com.br/prefeituras`, configure
+Vite and React Router to use the subpath:
+
+1. Set `base: '/prefeituras/'` in `vite.config.ts`.
+2. Set `basename="/prefeituras"` on `BrowserRouter` in `src/App.tsx`.
+
+Then build the project and preview the result locally:
+
+```sh
+npm run build
+npm run preview
+```


### PR DESCRIPTION
## Summary
- document how to deploy the app under `/prefeituras`

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*
- `npm run build` *(fails: vite not found)*
- `npm run preview` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7a35cac0832baf91c875442d38ae

## Resumo por Sourcery

Documentação:
- Adiciona seção README para implantação em `/prefeituras` com configurações do Vite e React Router.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add README section for deploying under `/prefeituras` with Vite and React Router settings.

</details>