### PR TITLE
Clarify setup order

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ git clone <YOUR_GIT_URL>
 # Step 2: Navigate to the project directory.
 cd <YOUR_PROJECT_NAME>
 
-# Step 3: Install the necessary dependencies.
-npm i
+# Step 3: Install the necessary dependencies. You must run this before
+# executing any `npm run lint`, `npm run dev`, or `npm run build` command.
+npm install
 
 # Step 4: Start the development server with auto-reloading and an instant preview.
 npm run dev


### PR DESCRIPTION
## Summary
- clarify that `npm install` must come before linting, dev or build

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run dev` *(fails: vite: not found)*
- `npm run build` *(fails: vite: not found)*
- `npm install` *(fails: 403 Forbidden while retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_684b7a3f8ba8832ba3d1d14c7fa82ac7