### PR TITLE
Fix base path for vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,18 @@ Then build the project and preview the result locally:
 npm run build
 npm run preview
 ```
+
+## Deploying on Vercel
+
+For a deployment at the root URL on Vercel, use the default configuration:
+
+1. Ensure `base` in `vite.config.ts` is set to `/`.
+2. Remove any `basename` prop from `BrowserRouter` in `src/App.tsx`.
+
+Then, run a production build:
+
+```sh
+npm run build
+```
+
+Vercel will automatically serve the built files from the `dist` directory.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,8 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter basename="/prefeituras">
+      {/* Use root URL for routing */}
+      <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,8 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: '/prefeituras/',
+  // Set base path to root for Vercel deployment
+  base: '/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- configure Vite base path for deployment at root
- remove custom `basename` from router
- add Vercel deployment instructions

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b7f3c49c0832b975b9b3b5930e53c

## Resumo por Sourcery

Configura o projeto para implantação na URL raiz no Vercel, atualizando o caminho base do Vite e a configuração do roteador, e documenta as etapas de implantação do Vercel no README.

Melhorias:
- Configura o Vite para usar o caminho base raiz para implantação no Vercel
- Remove a prop basename personalizada do BrowserRouter para habilitar o roteamento raiz

Documentação:
- Adiciona instruções de implantação do Vercel ao README

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Configure the project for deployment at the root URL on Vercel by updating the Vite base path and router configuration, and document the Vercel deployment steps in the README.

Enhancements:
- Configure Vite to use the root base path for Vercel deployment
- Remove custom basename prop from BrowserRouter to enable root routing

Documentation:
- Add Vercel deployment instructions to the README

</details>