### PR TITLE
Fix CTA heading color

### DIFF
--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -45,7 +45,7 @@ const CTASection: React.FC = () => {
         <CardContent className="p-8 md:p-12">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 items-center">
             <div>
-              <h2 className="text-3xl md:text-4xl font-bold mb-6 text-gov-blue">
+              <h2 className="text-3xl md:text-4xl font-bold mb-6 text-white">
                 Vamos inovar sua gestão pública?
               </h2>
 


### PR DESCRIPTION
## Summary
- update CTA heading color to white for better contrast

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8fbc0980832ba86245dcc7fe39cf

## Resumo por Sourcery

Correções de Bugs:
- Atualiza a cor do título da CTASection de gov-blue para branco para melhorar a legibilidade

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Update CTASection heading color from gov-blue to white to improve readability

</details>