### PR TITLE
Change CTA heading color

### DIFF
--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -45,7 +45,7 @@ const CTASection: React.FC = () => {
         <CardContent className="p-8 md:p-12">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 items-center">
             <div>
-              <h2 className="text-3xl md:text-4xl font-bold mb-6 text-blue">
+              <h2 className="text-3xl md:text-4xl font-bold mb-6 text-gov-blue">
                 Vamos inovar sua gestão pública?
               </h2>
 


### PR DESCRIPTION
## Summary
- use gov-blue (dark blue) for the "Vamos inovar sua gestão pública?" heading

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b92720554832b8b7e49c3481f27ec

## Resumo por Sourcery

Melhorias:
- Alterar a classe CSS do título da CTASection de `text-blue` para `text-gov-blue`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Change CTASection heading CSS class from text-blue to text-gov-blue

</details>